### PR TITLE
Enhancements

### DIFF
--- a/src/ini_reader.h
+++ b/src/ini_reader.h
@@ -22,6 +22,7 @@ enum
 typedef std::map<std::string, std::multimap<std::string, std::string>> ini_data_struct;
 typedef std::multimap<std::string, std::string> string_multimap;
 typedef std::vector<std::string> string_array;
+typedef std::string::size_type string_size;
 
 class INIReader
 {
@@ -898,6 +899,7 @@ public:
     std::string ToString()
     {
         std::string content;
+        string_size strsize;
 
         if(!parsed)
             return std::string();
@@ -907,16 +909,19 @@ public:
             content += "[" + x + "]\n";
             if(ini_content.find(x) != ini_content.end())
             {
-                for(auto &y : ini_content.at(x))
+                auto section = ini_content.at(x);
+                for(auto iter = section.begin(); iter != section.end(); iter++)
                 {
-                    if(y.first != "{NONAME}")
-                        content += y.first + "=";
-                    content += y.second + "\n";
+                    if(iter->first != "{NONAME}")
+                        content += iter->first + "=";
+                    content += iter->second + "\n";
+                    if(std::next(iter) == section.end())
+                        strsize = iter->second.size();
                 }
             }
-            content += "\n";
+            if(strsize)
+                content += "\n";
         }
-
         return content.erase(content.size() - 2);
     }
 

--- a/src/speedtestutil.cpp
+++ b/src/speedtestutil.cpp
@@ -1211,7 +1211,8 @@ bool explodeSurge(std::string surge, const std::string &custom_port, int local_p
     ini.SetIsolatedItemsSection("Proxy");
     ini.IncludeSection("Proxy");
     ini.AddDirectSaveSection("Proxy");
-    surge = regReplace(surge, "^#!.*$\\r?\\n", "");
+    if(surge.find("[Proxy]") != surge.npos)
+        surge = regReplace(surge, "^[\\S\\s]*?\\[", "[");
     ini.Parse(surge);
 
     if(!ini.SectionExist("Proxy"))

--- a/src/templates.cpp
+++ b/src/templates.cpp
@@ -70,8 +70,8 @@ int render_template(const std::string &content, const template_args &vars, std::
     });
     m_callbacks.add_callback("join", 3, [](inja::Arguments &args)
     {
-        std::string str1 = args.at(0)->get<std::string>(), str2 = args.at(1)->get<std::string>(), delim = args.at(2)->get<std::string>();
-        return std::move(str1) + std::move(delim) + std::move(str2);
+        std::string str1 = args.at(0)->get<std::string>(), str2 = args.at(1)->get<std::string>(), str3 = args.at(2)->get<std::string>();
+        return std::move(str1) + std::move(str2) + std::move(str3);
     });
     m_callbacks.add_callback("fetch", 1, template_webGet);
     m_callbacks.add_callback("parseHostname", 1, parseHostname);


### PR DESCRIPTION
Fix support for parsing some Surge configurations.
Fix adding extra blank line to section end when exporting some configurations.
Fix adding real internal link as MANAGED-CONFIG URL when using profile.
Fix not filtering load-balance group in Surfboard configurations. (Issue [#128](https://github.com/tindy2013/subconverter/issues/128)).
Fix rule type filter not working properly.
Add support for using template in external configurations.
Add relay group support for Clash configurations.
Optimize codes.