### PR TITLE
Fix implementation of using Clash rule-providers as rule sources

### DIFF
--- a/base/pref-new.yml
+++ b/base/pref-new.yml
@@ -62,6 +62,7 @@ managed_config:
 
 surge_external_proxy:
   surge_ssr_path: "" # /usr/bin/ssr-local
+  resolve_hostname: true
 
 emojis:
   add_emoji: true

--- a/base/pref.ini
+++ b/base/pref.ini
@@ -132,6 +132,7 @@ quanx_device_id=
 
 [surge_external_proxy]
 ;surge_ssr_path=/usr/bin/ssr-local
+resolve_hostname=true
 
 [emojis]
 add_emoji=true

--- a/src/interfaces.cpp
+++ b/src/interfaces.cpp
@@ -30,7 +30,7 @@ std::string listen_address = "127.0.0.1", default_url, insert_url, managed_confi
 int listen_port = 25500, max_pending_connections = 10, max_concurrent_threads = 4;
 bool prepend_insert_url = true;
 bool api_mode = true, write_managed_config = false, enable_rule_generator = true, update_ruleset_on_request = false, overwrite_original_rules = true;
-bool print_debug_info = false, cfw_child_process = false, append_userinfo = true, enable_base_gen = false, async_fetch_ruleset = false;
+bool print_debug_info = false, cfw_child_process = false, append_userinfo = true, enable_base_gen = false, async_fetch_ruleset = false, surge_ssr_resolve = true;
 std::string access_token, base_path = "base";
 extern std::string custom_group;
 extern int global_log_level;
@@ -676,7 +676,10 @@ void readYAMLConf(YAML::Node &node)
     }
 
     if(node["surge_external_proxy"].IsDefined())
+    {
         node["surge_external_proxy"]["surge_ssr_path"] >> surge_ssr_path;
+        node["surge_external_proxy"]["resolve_hostname"] >> surge_ssr_resolve;
+    }
 
     if(node["emojis"].IsDefined())
     {
@@ -869,6 +872,7 @@ void readConf()
     {
         ini.EnterSection("surge_external_proxy");
         ini.GetIfExist("surge_ssr_path", surge_ssr_path);
+        ini.GetBoolIfExist("resolve_hostname", surge_ssr_resolve);
     }
 
     if(ini.SectionExist("node_pref"))

--- a/src/subexport.cpp
+++ b/src/subexport.cpp
@@ -24,7 +24,7 @@
 #include "yamlcpp_extra.h"
 #include "interfaces.h"
 
-extern bool api_mode;
+extern bool api_mode, surge_ssr_resolve;
 extern string_array ss_ciphers, ssr_ciphers;
 extern size_t max_allowed_rules;
 
@@ -1611,8 +1611,11 @@ std::string netchToSurge(std::vector<nodeInfo> &nodes, const std::string &base_c
             {
                 return std::move(a) + "\", args=\"" + std::move(b);
             });
-            proxy += "\", local-port=" + std::to_string(local_port) + ", addresses=" + ((isIPv4(hostname) || isIPv6(hostname)) ? hostname : hostnameToIPAddr(hostname));
-            //proxy += "\", local-port=" + std::to_string(local_port);
+            proxy += "\", local-port=" + std::to_string(local_port);
+            if(isIPv4(hostname) || isIPv6(hostname))
+                proxy += ", addresses=" + hostname;
+            else if(surge_ssr_resolve)
+                proxy += ", addresses=" + hostnameToIPAddr(hostname);
             local_port++;
             break;
         case SPEEDTEST_MESSAGE_FOUNDSOCKS:


### PR DESCRIPTION
Add option for whether to try to resolve hostnames when generating ShadowsocksR nodes in Surge configurations.